### PR TITLE
Allow consumers to query for missing tags

### DIFF
--- a/SwiftOverpass/OverpassQuery.swift
+++ b/SwiftOverpass/OverpassQuery.swift
@@ -179,6 +179,10 @@ extension OverpassQuery {
         tags[key] = OverpassTag(key: key, value: value, isNegation: true)
     }
     
+    public func doesNotHaveTag(_ key: String) {
+        tags[key] = OverpassTag(key: key, value: ".", isNegation: true, isRegex: true)
+    }
+    
     /**
      Sets a tag to the query as regex tag
      

--- a/SwiftOverpass/OverpassQuery.swift
+++ b/SwiftOverpass/OverpassQuery.swift
@@ -179,6 +179,11 @@ extension OverpassQuery {
         tags[key] = OverpassTag(key: key, value: value, isNegation: true)
     }
     
+    /**
+     Marks a tag as not being supposed to contain an arbitary value.
+     
+     - parameter key: A key of the <has-kv> element
+     */
     public func doesNotHaveTag(_ key: String) {
         tags[key] = OverpassTag(key: key, value: ".", isNegation: true, isRegex: true)
     }


### PR DESCRIPTION
This enables consumers to restrict their query to those nodes that do not have
this tag assigned. Should result in the same nodes as described for Overpass QL here:
https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#Not_exists