### PR TITLE
Refactoring: Use switch/case instead of a force unwrap

### DIFF
--- a/SwiftOverpass/Queries/OverpassQuery.swift
+++ b/SwiftOverpass/Queries/OverpassQuery.swift
@@ -20,14 +20,15 @@ public enum OverpassQueryType {
     
     /// The string to creat a XML line.
     public var stringValue: String {
-        return OverpassQueryType.stringMapping[self]!
+        switch self {
+        case .node:
+            return "node"
+        case .way:
+            return "way"
+        case .relation:
+            return "relation"
+        }
     }
-    
-    fileprivate static let stringMapping = [
-        node: "node",
-        way: "way",
-        relation: "relation"
-    ]
 }
 
 /**


### PR DESCRIPTION
When adding new cases, the build will fail as the switch/case is not exhaustive.
This is more favorable than a crash because of a failed force-unwrap,
as it might be easy to forget about maintaining the array when adding a new case.